### PR TITLE
Correct NumPy/SciPy/SymPy Casing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Check out our full documentation: https://engineerjoe440.github.io/ElectricPy/
 
 ### Dependencies:
 
-- [numpy](https://numpy.org/)
+- [NumPy](https://numpy.org/)
 - [matplotlib](https://matplotlib.org/)
-- [scipy](https://scipy.org/)
-- [sympy](https://www.sympy.org/en/index.html)
+- [SciPy](https://scipy.org/)
+- [SymPy](https://www.sympy.org/en/index.html)
 - [numdifftools](https://numdifftools.readthedocs.io/en/latest/)
 
 


### PR DESCRIPTION
Updated the required stuff between lines 44 and 48 (both inclusive)